### PR TITLE
fix: improve Notion callout rendering and Umami analytics accuracy

### DIFF
--- a/datas/categories.ts
+++ b/datas/categories.ts
@@ -1,10 +1,15 @@
 import { Category } from '@/types';
 
-export const categories = [
+export const categories: Category[] = [
   {
     name: "Knowledge",
     description: "Programming knowledge and algorithm related articles.",
     value: ["code", "algorithm"],
+  },
+  {
+    name: "NAS & Smarthome DIY",
+    description: "Articles about NAS and Smarthome DIY.",
+    value: ["nas", "smarthome", "diy"],
   },
   {
     name: "Tutorial & Tips",

--- a/src/components/notion/blocks/BlockCallout.tsx
+++ b/src/components/notion/blocks/BlockCallout.tsx
@@ -41,6 +41,11 @@ export const BlockCallout: React.FC<BlockCalloutProps> = ({
       return children;
     }
 
+    // Check if block has title property (main callout content)
+    if (block.properties?.title) {
+      return <BlockRichText value={block.properties.title} block={block} />;
+    }
+
     // Try to manually render child blocks if recordMap is available
     if (recordMap && block.content && block.content.length > 0) {
       const childContent = block.content
@@ -76,9 +81,7 @@ export const BlockCallout: React.FC<BlockCalloutProps> = ({
     }
 
     // Fallback
-    return (
-      <div className="text-gray-500 text-sm italic">No content available</div>
-    );
+    return null;
   };
 
   const blockColor = block.format?.block_color;


### PR DESCRIPTION
- Fix BlockCallout to render block.properties.title content
- Remove 'No content available' fallback for better UX
- Add support for Umami API key authentication
- Create centralized createRequest() helper method
- Fix URL metrics merging by removing hash fragments and summing views
- Simplify getUrlPageviews() to reuse getUrlMetrics()
- Increase metrics limit from 1,000 to 100,000 URLs

Fixes issue where callout blocks displayed no content and analytics views were incorrectly counted due to URL hash fragments.